### PR TITLE
oauth-proxy: Add option to setup oauth with keycloak

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,13 +39,17 @@ alertmanager_receivers_extra: []
 #          send_resolved: true
 
 # OAuth
+alertmanager_oauth_provider: 'keycloak-oidc'
 alertmanager_oauth_compose_file: '{{ alertmanager_service_path }}/docker-compose.oauth.yml'
 alertmanager_oauth_cont_port: 8092
 #alertmanager_oauth_id: ~
 #alertmanager_oauth_secret: ~
 #alertmanager_oauth_cookie_secret: ~
-#alertmanager_oauth_gh_org: ~
+alertmanager_oauth_gh_org: 'status-im'
 alertmanager_oauth_gh_teams: []
+alertmanager_oauth_keycloak_realm: 'logos-co'
+alertmanager_oauth_keycloak_groups: []
+alertmanager_oauth_keycloak_roles: []
 
 # Route configuration
 alertmanager_group_by: ['alertname', 'fleet']

--- a/tasks/container.yml
+++ b/tasks/container.yml
@@ -10,18 +10,22 @@
 - name: Create OAuth compose file
   include_role: name=infra-role-oauth-proxy
   vars:
-    oauth_service_name:  '{{ alertmanager_service_name }}-oauth'
-    oauth_service_path:  '{{ alertmanager_service_path }}'
-    oauth_compose_path:  '{{ alertmanager_oauth_compose_file }}'
-    oauth_domain:        '{{ alertmanager_domain | mandatory }}'
-    oauth_github_org:    '{{ alertmanager_oauth_gh_org | mandatory }}'
-    oauth_github_teams:  '{{ alertmanager_oauth_gh_teams | mandatory }}'
-    oauth_id:            '{{ alertmanager_oauth_id | mandatory }}'
-    oauth_secret:        '{{ alertmanager_oauth_secret | mandatory }}'
-    oauth_cookie_secret: '{{ alertmanager_oauth_cookie_secret | mandatory }}'
-    oauth_local_port:    '{{ alertmanager_oauth_cont_port | mandatory }}'
-    oauth_local_addr:    '0.0.0.0'
-    oauth_upstream_url:  'http://app:{{ alertmanager_webui_port }}/'
+    oauth_service_name:    '{{ alertmanager_service_name }}-oauth'
+    oauth_service_path:    '{{ alertmanager_service_path }}'
+    oauth_compose_path:    '{{ alertmanager_oauth_compose_file }}'
+    oauth_provider:        '{{ alertmanager_oauth_provider | mandatory }}'
+    oauth_domain:          '{{ alertmanager_domain | mandatory }}'
+    oauth_github_org:      '{{ alertmanager_oauth_gh_org }}'
+    oauth_github_teams:    '{{ alertmanager_oauth_gh_teams }}'
+    oauth_keycloak_realm:  '{{ alertmanager_oauth_keycloak_realm }}'
+    oauth_keycloak_groups: '{{ alertmanager_oauth_keycloak_groups }}'
+    oauth_keycloak_roles:  '{{ alertmanager_oauth_keycloak_roles }}'
+    oauth_id:              '{{ alertmanager_oauth_id | mandatory }}'
+    oauth_secret:          '{{ alertmanager_oauth_secret | mandatory }}'
+    oauth_cookie_secret:   '{{ alertmanager_oauth_cookie_secret | mandatory }}'
+    oauth_local_port:      '{{ alertmanager_oauth_cont_port | mandatory }}'
+    oauth_local_addr:      '0.0.0.0'
+    oauth_upstream_url:    'http://app:{{ alertmanager_webui_port }}/'
 
 - name: Create containers
   docker_compose:


### PR DESCRIPTION
Modify the call to oauth proxy role so it is possible to use keycloak-oidc provider along with github.

Referenced issue: https://github.com/status-im/infra-misc/issues/285